### PR TITLE
api tasks: add literal_evals option

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -453,7 +453,7 @@ List tasks
                 for name in ['args', 'kwargs', 'result']:
                     try:
                         task[name + '_e'] = literal_eval(task[name])
-                    except:
+                    except (ValueError, SyntaxError, TypeError):
                         task[name + '_e'] = None
             result.append((task_id, task))
         self.write(dict(result))
@@ -569,6 +569,6 @@ Get a task info
             for name in ['args', 'kwargs', 'result']:
                 try:
                     response[name + '_e'] = literal_eval(getattr(task, name))
-                except:
+                except (ValueError, SyntaxError, TypeError):
                     response[name + '_e'] = None
         self.write(response)

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -5,11 +5,13 @@ import logging
 
 from datetime import datetime
 from threading import Thread
+from ast import literal_eval
 
 from tornado import web
 from tornado import gen
 from tornado.escape import json_decode
 from tornado.web import HTTPError
+from tornado.options import options
 
 from celery import states
 from celery.result import AsyncResult
@@ -139,7 +141,7 @@ Execute a task by name and wait results
 
         # In tornado for not blocking event loop we must return results
         # from other thread by self.finish()
-        th = Thread(target=self.wait_results, args=(result, response, ))
+        th = Thread(target=self.wait_results, args=(result, response,))
         th.start()
         # So just exit
 
@@ -447,6 +449,12 @@ List tasks
                 worker=worker, state=state):
             task = tasks.as_dict(task)
             task.pop('worker', None)
+            if options.literal_eval_args:
+                for name in ['args', 'kwargs', 'result']:
+                    try:
+                        task[name + '_e'] = literal_eval(task[name])
+                    except:
+                        task[name + '_e'] = None
             result.append((task_id, task))
         self.write(dict(result))
 
@@ -557,4 +565,10 @@ Get a task info
                 response[name] = getattr(task, name, None)
         response['task-id'] = task.uuid
         response['worker'] = task.worker.hostname
+        if options.literal_eval_args:
+            for name in ['args', 'kwargs', 'result']:
+                try:
+                    response[name + '_e'] = literal_eval(getattr(task, name))
+                except:
+                    response[name + '_e'] = None
         self.write(response)

--- a/flower/options.py
+++ b/flower/options.py
@@ -62,6 +62,8 @@ define("tasks_columns", type=str,
        help="Slugs of columns on /tasks/ page, delimited by comma")
 define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
        help="auth handler class")
+define("literal_eval_args", type=bool, default=False,
+       help="attempt basic ast.literal_eval on pickled fields (e.g., kwargs)")
 
 # deprecated options
 define("url_prefix", type=str, help="base url prefix")


### PR DESCRIPTION
Adds the option to use runtime `--literal_eval_args=True` (or via normal config option in flowerconf), which adds `args_e`, `kwargs_e`, and `result_e`  to /api/task[s] endpoints.  Uses `ast.literal_eval` for safety, and falls back to `None` when any problems are encountered.