### PR TITLE
Pin celery dependency version

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-celery>=3.1.0
+celery>=3.1.19
 tornado==4.2.0
 babel==2.2.0
 pytz==2015.7

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-celery>=3.1.19
+celery==3.1.19
 tornado==4.2.0
 babel==2.2.0
 pytz==2015.7


### PR DESCRIPTION
Hard pin celery to the version used by rewardStyle/gorden, so that pipenv does not munge the version when installing flower as a dependency for gorden.